### PR TITLE
Configurable cache path

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,8 +23,8 @@ var config struct {
 	// TaskConfigs is a list of task definitions and their metadata
 	TaskConfigs []TaskConfig `yaml:"tasks"`
 
-	// cachePath is the dir path to place any temporary files
-	cachePath string
+	// CachePath is the dir path to place any temporary files
+	CachePath string
 
 	// logCachePath is the dir path to place temporary logs
 	logCachePath string
@@ -250,17 +250,19 @@ func removeOneValue(slice []float64, value float64) []float64 {
 
 // readTimeCache fetches and reads a cache file from disk containing CmdString-to-ETASeconds. Note: this this must be done before fetching/parsing the run.yaml
 func readTimeCache() {
-	cwd, err := os.Getwd()
-	CheckError(err, "Unable to get CWD.")
+	if config.CachePath == "" {
+		cwd, err := os.Getwd()
+		CheckError(err, "Unable to get CWD.")
+		config.CachePath = path.Join(cwd, ".bashful")
+	}
 
-	config.cachePath = path.Join(cwd, ".bashful")
-	config.downloadCachePath = path.Join(config.cachePath, "downloads")
-	config.logCachePath = path.Join(config.cachePath, "logs")
-	config.etaCachePath = path.Join(config.cachePath, "eta")
+	config.downloadCachePath = path.Join(config.CachePath, "downloads")
+	config.logCachePath = path.Join(config.CachePath, "logs")
+	config.etaCachePath = path.Join(config.CachePath, "eta")
 
 	// create the cache dirs if they do not already exist
-	if _, err := os.Stat(config.cachePath); os.IsNotExist(err) {
-		os.Mkdir(config.cachePath, 0755)
+	if _, err := os.Stat(config.CachePath); os.IsNotExist(err) {
+		os.Mkdir(config.CachePath, 0755)
 	}
 	if _, err := os.Stat(config.downloadCachePath); os.IsNotExist(err) {
 		os.Mkdir(config.downloadCachePath, 0755)

--- a/log.go
+++ b/log.go
@@ -55,7 +55,7 @@ func removeDirContents(dir string) error {
 
 func setupLogging() {
 
-	err := os.MkdirAll(config.cachePath, 0755)
+	err := os.MkdirAll(config.CachePath, 0755)
 	if err != nil {
 		exitWithErrorMessage("\nUnable to create cache dir\n" + err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func bundle(userYamlPath, outputPath string) {
 	/*  */
 	bashfulPath, err := filepath.Abs(os.Args[0])
 	CheckError(err, "Could not find path to bashful")
-	archiver.TarGz.Make(archivePath, []string{userYamlPath, bashfulPath, config.cachePath})
+	archiver.TarGz.Make(archivePath, []string{userYamlPath, bashfulPath, config.CachePath})
 
 	execute := `#!/bin/bash
 set -eu
@@ -325,6 +325,14 @@ func main() {
 	app.Name = "bashful"
 	app.Version = "Version:   " + Version + "\n   Commit:    " + GitCommit + "\n   BuildTime: " + BuildTime
 	app.Usage = "Takes a yaml file containing commands and bash snippits and executes each command while showing a simple (vertical) progress bar."
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "cache-path",
+			Value:       "",
+			Usage:       "The path where cached files will be stored. By default '$(pwd)/.bashful' is used.",
+			Destination: &config.CachePath,
+		},
+	}
 	app.Commands = []cli.Command{
 		{
 			Name:  "bundle",


### PR DESCRIPTION
Having the cache path created in the current directory may not be convenient. bashful could be invoked from a directory where the user does not have write permissions, and the execution would fail because the cache directory can't be created.