### PR TITLE
Add basic sudo support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ $(TARGETS):
 
 run:
 	go run main.go task.go config.go screen.go download.go log.go \
-	run example/13-single-line.yml
+	run example/14-sudo.yml
 
 examples: clean build
 	./dist/bashful run example/00-demo.yml

--- a/config.go
+++ b/config.go
@@ -198,6 +198,9 @@ type TaskConfig struct {
 	// StopOnFailure indicates to halt further program execution if a task command has a non-zero return code
 	StopOnFailure bool `yaml:"stop-on-failure"`
 
+	// Sudo indicates that the given command should be run with the given sudo credentials
+	Sudo bool `yaml:"sudo"`
+
 	// Tags is a list of strings that is used to filter down which task are run at runtime
 	Tags   stringArray `yaml:"tags"`
 	TagSet mapset.Set

--- a/example/14-sudo.yml
+++ b/example/14-sudo.yml
@@ -1,0 +1,9 @@
+tasks:
+  # if a command shold be run with sudo, flag it as so...
+  - cmd: touch /bin/true
+    sudo: true
+
+  #... *don't* put sudo in your cmd
+  - cmd: sudo touch /bin/true
+    stop-on-failure: false
+

--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ __BASHFUL_ARCHIVE__
 
 }
 
-func StoreSudoPasswd() {
+func storeSudoPasswd() {
 	var sout bytes.Buffer
 
 	// check if there is a task that requires sudo
@@ -256,7 +256,7 @@ func run(yamlString []byte, environment map[string]string) []*Task {
 
 	ParseConfig(yamlString)
 	allTasks = CreateTasks()
-	StoreSudoPasswd()
+	storeSudoPasswd()
 
 	DownloadAssets(allTasks)
 

--- a/task.go
+++ b/task.go
@@ -261,7 +261,11 @@ func (task *Task) inflateCmd() {
 	readFd, writeFd, err := os.Pipe()
 	checkError(err, "Could not open env pipe for child shell")
 
-	task.Command.Cmd = exec.Command(shell, "-c", task.Config.CmdString+"; BASHFUL_RC=$?; env >&3; exit $BASHFUL_RC")
+	sudoCmd := ""
+	if task.Config.Sudo {
+		sudoCmd = "sudo -S "
+	}
+	task.Command.Cmd = exec.Command(shell, "-c", sudoCmd+task.Config.CmdString+"; BASHFUL_RC=$?; env >&3; exit $BASHFUL_RC")
 
 	// allow the child process to provide env vars via a pipe (FD3)
 	task.Command.Cmd.ExtraFiles = []*os.File{writeFd}

--- a/task.go
+++ b/task.go
@@ -266,6 +266,7 @@ func (task *Task) inflateCmd() {
 		sudoCmd = "sudo -S "
 	}
 	task.Command.Cmd = exec.Command(shell, "-c", sudoCmd+task.Config.CmdString+"; BASHFUL_RC=$?; env >&3; exit $BASHFUL_RC")
+	task.Command.Cmd.Stdin = strings.NewReader(string(sudoPassword) + "\n")
 
 	// allow the child process to provide env vars via a pipe (FD3)
 	task.Command.Cmd.ExtraFiles = []*os.File{writeFd}


### PR DESCRIPTION
For #37 , this captures a user's password and attempts to run flagged commands with sudo (and automatically provide the password). This will not work for tailored sudoers files for particular commands since this is testing against `/bin/true` for the need to ask for credentials... so it is possible for bashful to not ask for a sudo password when one will be needed during execution (leaving bashful running forever as a subprocess is waiting for user input). Even with this pitfall, this is probably 'good enough' for now.