### PR TITLE
Fixed import order using goimports

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -22,12 +22,13 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"github.com/wagoodman/bashful/pkg/config"
 	"github.com/wagoodman/bashful/pkg/runtime"
 	"github.com/wagoodman/bashful/utils"
-	"io/ioutil"
-	"path/filepath"
 )
 
 // bundleCmd represents the bundle command

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,7 +22,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/deckarep/golang-set"
+
+	mapset "github.com/deckarep/golang-set"
+
+	"io/ioutil"
+	"math/rand"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wagoodman/bashful/pkg/config"
@@ -30,10 +36,6 @@ import (
 	"github.com/wagoodman/bashful/pkg/runtime"
 	"github.com/wagoodman/bashful/pkg/runtime/handler"
 	"github.com/wagoodman/bashful/utils"
-	"io/ioutil"
-	"math/rand"
-	"strings"
-	"time"
 )
 
 // todo: put these in a cli struct instance instead, then most logic can be in the cli struct

--- a/pkg/config/assemble.go
+++ b/pkg/config/assemble.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/spf13/afero"
-	"github.com/wagoodman/bashful/utils"
 	"regexp"
 	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/wagoodman/bashful/utils"
 )
 
 type assembler struct {

--- a/pkg/config/assemble_test.go
+++ b/pkg/config/assemble_test.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"bytes"
-	"github.com/spf13/afero"
 	"testing"
+
+	"github.com/spf13/afero"
 )
 
 func TestYamlInclude(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,13 +22,14 @@ package config
 
 import (
 	"fmt"
-	"github.com/deckarep/golang-set"
-	"github.com/spf13/afero"
-	"github.com/wagoodman/bashful/utils"
-	"gopkg.in/yaml.v2"
 	"os"
 	"path"
 	"strings"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/spf13/afero"
+	"github.com/wagoodman/bashful/utils"
+	"gopkg.in/yaml.v2"
 )
 
 var globalOptions *Options

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/deckarep/golang-set"
-	"github.com/wagoodman/bashful/utils"
 	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/wagoodman/bashful/utils"
 )
 
 func Test_Compile_SingleTask(t *testing.T) {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -21,7 +21,7 @@
 package config
 
 import (
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 )
 
 type stringArray []string

--- a/pkg/runtime/archive.go
+++ b/pkg/runtime/archive.go
@@ -24,11 +24,12 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"errors"
-	"github.com/wagoodman/bashful/utils"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/wagoodman/bashful/utils"
 )
 
 type Archiver interface {

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -23,14 +23,15 @@ package runtime
 import (
 	"bytes"
 	"fmt"
-	"github.com/wagoodman/bashful/pkg/config"
-	"github.com/wagoodman/bashful/pkg/log"
-	"github.com/wagoodman/bashful/utils"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"text/template"
+
+	"github.com/wagoodman/bashful/pkg/config"
+	"github.com/wagoodman/bashful/pkg/log"
+	"github.com/wagoodman/bashful/utils"
 )
 
 func NewClientFromYaml(yamlString []byte, cli *config.Cli) (*Client, error) {

--- a/pkg/runtime/command.go
+++ b/pkg/runtime/command.go
@@ -2,13 +2,14 @@ package runtime
 
 import (
 	"bytes"
-	"github.com/wagoodman/bashful/pkg/config"
-	"github.com/wagoodman/bashful/utils"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/wagoodman/bashful/pkg/config"
+	"github.com/wagoodman/bashful/utils"
 )
 
 func newCommand(taskConfig config.TaskConfig) command {

--- a/pkg/runtime/downloader.go
+++ b/pkg/runtime/downloader.go
@@ -22,11 +22,12 @@ package runtime
 
 import (
 	"fmt"
-	"github.com/deckarep/golang-set"
 	"os"
 	"path"
 	"sync"
 	"time"
+
+	mapset "github.com/deckarep/golang-set"
 
 	"github.com/cavaliercoder/grab"
 	"github.com/dustin/go-humanize"

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -22,11 +22,12 @@ package runtime
 
 import (
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/wagoodman/bashful/pkg/config"
 	"github.com/wagoodman/bashful/pkg/log"
 	"github.com/wagoodman/bashful/utils"
-	"os"
-	"time"
 )
 
 func newExecutorStats() *TaskStatistics {

--- a/pkg/runtime/executor_test.go
+++ b/pkg/runtime/executor_test.go
@@ -2,9 +2,10 @@ package runtime
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/lunixbochs/vtclean"
 	"github.com/wagoodman/bashful/pkg/config"
-	"testing"
 )
 
 // Test harness...

--- a/pkg/runtime/handler/compressed_ui.go
+++ b/pkg/runtime/handler/compressed_ui.go
@@ -2,16 +2,17 @@ package handler
 
 import (
 	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	color "github.com/mgutz/ansi"
 	"github.com/wagoodman/bashful/pkg/config"
 	"github.com/wagoodman/bashful/pkg/runtime"
 	"github.com/wagoodman/bashful/utils"
 	"github.com/wagoodman/jotframe"
-	"github.com/wayneashleyberry/terminal-dimensions"
-	"strconv"
-	"sync"
-	"time"
+	terminaldimensions "github.com/wayneashleyberry/terminal-dimensions"
 )
 
 type cUiData struct {

--- a/pkg/runtime/handler/simple_logger.go
+++ b/pkg/runtime/handler/simple_logger.go
@@ -2,9 +2,10 @@ package handler
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/wagoodman/bashful/pkg/config"
 	"github.com/wagoodman/bashful/pkg/runtime"
-	"os"
 )
 
 // this was just a (successful) experiment :) needs to be reworked

--- a/pkg/runtime/handler/task_logger.go
+++ b/pkg/runtime/handler/task_logger.go
@@ -1,15 +1,16 @@
 package handler
 
 import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"sync"
+
 	"github.com/google/uuid"
 	"github.com/wagoodman/bashful/pkg/config"
 	"github.com/wagoodman/bashful/pkg/log"
 	"github.com/wagoodman/bashful/pkg/runtime"
 	"github.com/wagoodman/bashful/utils"
-	"io/ioutil"
-	"os"
-	"strconv"
-	"sync"
 )
 
 type bufferedLog struct {

--- a/pkg/runtime/handler/vertical_ui.go
+++ b/pkg/runtime/handler/vertical_ui.go
@@ -3,6 +3,13 @@ package handler
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
 	"github.com/google/uuid"
 	color "github.com/mgutz/ansi"
 	"github.com/tj/go-spin"
@@ -10,13 +17,7 @@ import (
 	"github.com/wagoodman/bashful/pkg/runtime"
 	"github.com/wagoodman/bashful/utils"
 	"github.com/wagoodman/jotframe"
-	"github.com/wayneashleyberry/terminal-dimensions"
-	"io"
-	"strconv"
-	"strings"
-	"sync"
-	"text/template"
-	"time"
+	terminaldimensions "github.com/wayneashleyberry/terminal-dimensions"
 )
 
 type VerticalUI struct {

--- a/pkg/runtime/root.go
+++ b/pkg/runtime/root.go
@@ -21,10 +21,11 @@
 package runtime
 
 import (
-	"github.com/wagoodman/bashful/utils"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/wagoodman/bashful/utils"
 )
 
 func Setup() {

--- a/pkg/runtime/task.go
+++ b/pkg/runtime/task.go
@@ -36,7 +36,7 @@ import (
 	"github.com/lunixbochs/vtclean"
 	"github.com/wagoodman/bashful/pkg/config"
 	"github.com/wagoodman/bashful/utils"
-	"github.com/wayneashleyberry/terminal-dimensions"
+	terminaldimensions "github.com/wayneashleyberry/terminal-dimensions"
 )
 
 // todo: remove these global vars

--- a/pkg/runtime/task_test.go
+++ b/pkg/runtime/task_test.go
@@ -1,11 +1,12 @@
 package runtime
 
 import (
-	"github.com/lunixbochs/vtclean"
-	"github.com/wagoodman/bashful/pkg/config"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/lunixbochs/vtclean"
+	"github.com/wagoodman/bashful/pkg/config"
 )
 
 func Test_Task_estimateRuntime(t *testing.T) {

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -22,12 +22,13 @@ package runtime
 
 import (
 	"bytes"
-	"github.com/google/uuid"
-	"github.com/wagoodman/bashful/pkg/config"
 	"os"
 	"os/exec"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/wagoodman/bashful/pkg/config"
 )
 
 // EventHandler represents a type that can listen to Task events managed by the Executor

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,8 +6,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"github.com/howeyc/gopass"
-	color "github.com/mgutz/ansi"
 	"io"
 	"net/url"
 	"os"
@@ -15,6 +13,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/howeyc/gopass"
+	color "github.com/mgutz/ansi"
 )
 
 var (

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	"github.com/alecthomas/repr"
 	"testing"
+
+	"github.com/alecthomas/repr"
 )
 
 func TestMinMax(t *testing.T) {


### PR DESCRIPTION
Keeps the import order clean and just avoids future merge conflicts.