### PR TITLE
Use the passed in yamlString instead of ignoring it

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -58,9 +58,6 @@ func init() {
 
 func Bundle(yamlString []byte, outputPath string, cli config.Cli) {
 
-	yamlString, err := ioutil.ReadFile(cli.YamlPath)
-	utils.CheckError(err, "Unable to read yaml Config.")
-
 	client, err := runtime.NewClientFromYaml(yamlString, &cli)
 	if err != nil {
 		utils.ExitWithErrorMessage(err.Error())


### PR DESCRIPTION
We already parse the yamlString and pass it into Bundle, use it.